### PR TITLE
[dbapi] Fix, we need to be strict and return a list of tuples

### DIFF
--- a/es/baseapi.py
+++ b/es/baseapi.py
@@ -76,13 +76,11 @@ class BaseConnection(object):
     @check_closed
     def commit(self):
         """
-        Commit any pending transaction to the database.
+        Elasticsearch doesn't support transactions.
 
-        Not supported.
+        So just do nothing to support this method.
         """
-        raise exceptions.NotSupportedError(
-            "This is a readonly dbapi commit is not supported"
-        )
+        pass
 
     @check_closed
     def cursor(self):

--- a/es/baseapi.py
+++ b/es/baseapi.py
@@ -198,8 +198,6 @@ class BaseCursor(object):
     next = __next__
 
     def sanitize_query(self, query):
-        query = query.replace("  ", " ")
-        query = query.replace("\n", " ")
         # remove dummy schema from queries
         return query.replace(f'FROM "{DEFAULT_SCHEMA}".', "FROM ")
 

--- a/es/elastic/api.py
+++ b/es/elastic/api.py
@@ -137,7 +137,8 @@ class Cursor(BaseCursor):
 
         query = apply_parameters(operation, parameters)
         results = self.elastic_query(query)
-        rows = results.get("rows")
+        # We need a list of tuples
+        rows = [tuple(row) for row in results.get("rows")]
         columns = results.get("columns")
         if not columns:
             raise exceptions.DataError(

--- a/es/tests/test_dbapi.py
+++ b/es/tests/test_dbapi.py
@@ -101,6 +101,9 @@ class TestData(unittest.TestCase):
         DBAPI: Test execute select all (*)
         """
         rows = self.cursor.execute("select * from flights LIMIT 10").fetchall()
+        # Make sure we have a list of tuples
+        self.assertEqual(type(rows), type(list()))
+        self.assertEqual(type(rows[0]), type(tuple()))
         self.assertEquals(len(rows), 10)
 
     def test_boolean_description(self):

--- a/es/tests/test_dbapi.py
+++ b/es/tests/test_dbapi.py
@@ -46,12 +46,11 @@ class TestData(unittest.TestCase):
         rows = self.conn.execute("select Carrier from flights").fetchall()
         self.assertGreater(len(rows), 1)
 
-    def test_commit_not_supported(self):
+    def test_commit_executes(self):
         """
-        DBAPI: Test commit not supported failure
+        DBAPI: Test commit method exists
         """
-        with self.assertRaises(NotSupportedError):
-            self.conn.commit()
+        self.conn.commit()
 
     def test_executemany_not_supported(self):
         """


### PR DESCRIPTION
By default elasticsearch SQL endpoint returns `List[List]]` but we need to return `List[Tuple]`