### PR TITLE
[elasticsearch] Fix, newer elasticsearch version were crashing

### DIFF
--- a/es/elastic/api.py
+++ b/es/elastic/api.py
@@ -156,7 +156,7 @@ class Cursor(BaseCursor):
         """
         array_columns = []
         try:
-            resp = self.es.search(table_name, size=1)
+            resp = self.es.search(index=table_name, size=1)
         except es_exceptions.ConnectionError as e:
             raise exceptions.OperationalError(
                 f"Error connecting to {self.url}: {e.info}"


### PR DESCRIPTION
Newer elasticsearch-py version (7.5.1, 7.6.0) were crashing, `es.search` was probably using a deprecated method signature

Issues: #21, #19 
and maybe: #20 
