### PR TITLE
Bump to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change log
 
+### 0.1.2
+
+- [elasticsearch] Fix, newer elasticsearch version were crashing (#23)
+
 ### 0.1.1
 
 - [dbapi] Fix, enforce list tuple to follow PEP-249 (#17)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 from setuptools import find_packages, setup
 
-VERSION = "0.1.1"
+VERSION = "0.1.2"
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 with io.open("README.md", "r", encoding="utf-8") as f:


### PR DESCRIPTION
New 0.1.2

### 0.1.2

- [elasticsearch] Fix, newer elasticsearch version were crashing (#23)
