### PR TITLE
release: bump to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 ## Change log
 
+### 0.1.3
+
+- [elasticsearch]: feat: `fetch_size` configurable and set default to 10000 (#30) 
+- [docs]: fix: Update README.md (#32)
+
 ### 0.1.2
 
-- [elasticsearch] Fix, newer elasticsearch version were crashing (#23)
+- [elasticsearch] fix: newer elasticsearch version were crashing (#23)
 
 ### 0.1.1
 
-- [dbapi] Fix, enforce list tuple to follow PEP-249 (#17)
-- [dbapi] Fix, don't do anything in commit method (#16)
-- [dbapi] Improve support connection string without trailing slash (#9)
+- [dbapi] fix: enforce list tuple to follow PEP-249 (#17)
+- [dbapi] fix: don't do anything in commit method (#16)
+- [dbapi] fix: support connection string without trailing slash (#9)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,13 @@ services:
       - 9200:9200
       - 9300:9300
 
+  opendistro:
+    image: amazon/opendistro-for-elasticsearch:1.7.0
+    env_file: .env
+    ports:
+      - 9400:9200
+      - 9500:9300
+
   kibana:
     image: docker.elastic.co/kibana/kibana:7.3.2
     env_file: .env

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 from setuptools import find_packages, setup
 
-VERSION = "0.1.2"
+VERSION = "0.1.3"
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 with io.open("README.md", "r", encoding="utf-8") as f:


### PR DESCRIPTION
Release 0.1.3:

```
- [elasticsearch]: feat: `fetch_size` configurable and set default to 10000 (#30) 
- [docs]: fix: Update README.md (#32)
```

ping @Alexander-N