### PR TITLE
feat(opendistro): implement get view names with ES alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,11 @@ engine = create_engine(
 )
 ```
 
-IAM AWS Authentication keys is configured has query parameters on the URI
+IAM AWS Authentication keys are passed on the URI basic auth location, and by setting `aws_keys`
 
 Query string keys are:
 
-- aws_access_key
-- aws_secret_key
+- aws_keys
 - aws_region
 
 ```python

--- a/README.md
+++ b/README.md
@@ -214,4 +214,5 @@ SQLAlchemy `get_columns` will exclude them.
 - AWS ES (opendistro elascticsearch) is supported (still beta), known limitations are:
   * You are only able to `GROUP BY` keyword fields (new [experimental](https://github.com/opendistro-for-elasticsearch/sql#experimental) 
  opendistro SQL already supports it)
-  * Indices with dots are not supported (indices like 'audit_log.2021.01.20')
+  * Indices with dots are not supported (indices like 'audit_log.2021.01.20'), 
+  on these cases we recommend the use of aliases

--- a/es/baseapi.py
+++ b/es/baseapi.py
@@ -165,13 +165,15 @@ class BaseConnection(object):
         self.close()
 
 
-class BaseCursor(object):
+class BaseCursor:
     """Connection cursor."""
 
-    custom_sql_to_method = {}
+    custom_sql_to_method: Dict[str, str] = {}
     """
     Each child implements custom SQL commands so that we can
-    add extra missing logic or restrictions
+    add extra missing logic or restrictions.
+    Maps custom SQL to class methods, cursor execute calls a dispatcher
+    based on this mapping.
     """
 
     def __init__(self, url: str, es: Elasticsearch, **kwargs):
@@ -201,7 +203,7 @@ class BaseCursor(object):
         # this is set to an iterator after a successful query
         self._results: List[Tuple[Any, ...]] = []
 
-    def custom_sql_to_method_dispatcher(self, command: str) -> Optional["Cursor"]:
+    def custom_sql_to_method_dispatcher(self, command: str) -> Optional["BaseCursor"]:
         """
         Generic CUSTOM SQL dispatcher for internal methods
         :param command: str
@@ -210,6 +212,7 @@ class BaseCursor(object):
         command_ = command.lower()
         if command_ in self.custom_sql_to_method:
             return getattr(self, self.custom_sql_to_method[command_])()
+        return None
 
     @property  # type: ignore
     @check_result

--- a/es/baseapi.py
+++ b/es/baseapi.py
@@ -209,10 +209,8 @@ class BaseCursor:
         :param command: str
         :return: None if no command found, or a Cursor with the result
         """
-        command_ = command.lower()
-        if command_ in self.custom_sql_to_method:
-            return getattr(self, self.custom_sql_to_method[command_])()
-        return None
+        method_name = self.custom_sql_to_method.get(command.lower())
+        return getattr(self, method_name)() if method_name else None
 
     @property  # type: ignore
     @check_result

--- a/es/baseapi.py
+++ b/es/baseapi.py
@@ -230,7 +230,7 @@ class BaseCursor:
 
     @check_closed
     def execute(self, operation, parameters=None) -> "BaseCursor":
-        """ Childs must implement their own custom execute """
+        """ Children must implement their own custom execute """
         raise NotImplementedError  # pragma: no cover
 
     @check_closed

--- a/es/basesqlalchemy.py
+++ b/es/basesqlalchemy.py
@@ -189,7 +189,7 @@ class BaseESDialect(default.DefaultDialect):
         return True
 
 
-def get_type(data_type):
+def get_type(data_type: str) -> int:
     type_map = {
         "bytes": types.LargeBinary,
         "boolean": types.Boolean,

--- a/es/basesqlalchemy.py
+++ b/es/basesqlalchemy.py
@@ -147,13 +147,13 @@ class BaseESDialect(default.DefaultDialect):
         return table_name in self.get_table_names(connection, schema)
 
     def get_table_names(self, connection, schema=None, **kwargs) -> List[str]:
-        pass
+        pass  # pragma: no cover
 
     def get_columns(self, connection, table_name, schema=None, **kw):
-        pass
+        pass  # pragma: no cover
 
     def get_view_names(self, connection, schema=None, **kwargs):
-        return []
+        return []  # pragma: no cover
 
     def get_table_options(self, connection, table_name, schema=None, **kwargs):
         return {}

--- a/es/elastic/api.py
+++ b/es/elastic/api.py
@@ -124,7 +124,7 @@ class Cursor(BaseCursor):
         if operation == "SHOW VALID_TABLES":
             return self.get_valid_table_names()
 
-        if operation == "SHOW VALID_VIEWS":
+        elif operation == "SHOW VALID_VIEWS":
             return self.get_valid_view_names()
 
         re_table_name = re.match("SHOW ARRAY_COLUMNS FROM (.*)", operation)

--- a/es/elastic/api.py
+++ b/es/elastic/api.py
@@ -77,6 +77,11 @@ class Cursor(BaseCursor):
 
     """Connection cursor."""
 
+    custom_sql_to_method = {
+        "show valid_tables": "get_valid_table_names",
+        "show valid_views": "get_valid_view_names",
+    }
+
     def __init__(self, url: str, es: Elasticsearch, **kwargs: Any) -> None:
         super().__init__(url, es, **kwargs)
         self.sql_path = kwargs.get("sql_path") or "_sql"
@@ -119,11 +124,9 @@ class Cursor(BaseCursor):
     def execute(
         self, operation: str, parameters: Optional[Dict[str, Any]] = None
     ) -> "Cursor":
-        if operation == "SHOW VALID_TABLES":
-            return self.get_valid_table_names()
-
-        elif operation == "SHOW VALID_VIEWS":
-            return self.get_valid_view_names()
+        cursor = self.custom_sql_to_method_dispatcher(operation)
+        if cursor:
+            return cursor
 
         re_table_name = re.match("SHOW ARRAY_COLUMNS FROM (.*)", operation)
         if re_table_name:

--- a/es/elastic/api.py
+++ b/es/elastic/api.py
@@ -123,7 +123,7 @@ class Cursor(BaseCursor):
     @check_closed
     def execute(
         self, operation: str, parameters: Optional[Dict[str, Any]] = None
-    ) -> "Cursor":
+    ) -> "BaseCursor":
         cursor = self.custom_sql_to_method_dispatcher(operation)
         if cursor:
             return cursor

--- a/es/elastic/sqlalchemy.py
+++ b/es/elastic/sqlalchemy.py
@@ -1,13 +1,10 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import logging
-from typing import List
+from types import ModuleType
+from typing import Any, Dict, List, Optional
 
 from es import basesqlalchemy
 import es.elastic
+from sqlalchemy.engine import Connection
 
 logger = logging.getLogger(__name__)
 
@@ -29,28 +26,38 @@ class ESDialect(basesqlalchemy.BaseESDialect):
     type_compiler = ESTypeCompiler
 
     @classmethod
-    def dbapi(cls):
+    def dbapi(cls) -> ModuleType:
         return es.elastic
 
-    def get_table_names(self, connection, schema=None, **kwargs) -> List[str]:
+    def get_table_names(
+        self, connection: Connection, schema: Optional[str] = None, **kwargs: Any
+    ) -> List[str]:
         query = "SHOW VALID_TABLES"
         result = connection.execute(query)
         # return a list of table names exclude hidden and empty indexes
         return [table.name for table in result if table.name[0] != "."]
 
-    def get_view_names(self, connection, schema=None, **kwargs) -> List[str]:
+    def get_view_names(
+        self, connection: Connection, schema: Optional[str] = None, **kwargs: Any
+    ) -> List[str]:
         query = "SHOW VALID_VIEWS"
         result = connection.execute(query)
         # return a list of view names (ES aliases) exclude hidden and empty indexes
         return [table.name for table in result if table.name[0] != "."]
 
-    def get_columns(self, connection, table_name, schema=None, **kwargs):
+    def get_columns(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: Optional[str] = None,
+        **kwargs: Any,
+    ) -> List[Dict[str, Any]]:
         query = f'SHOW COLUMNS FROM "{table_name}"'
         # A bit of an hack this cmd does not exist on ES
         array_columns_ = connection.execute(
             f"SHOW ARRAY_COLUMNS FROM {table_name}"
         ).fetchall()
-        if len(array_columns_[0]) == 0:
+        if not array_columns_:
             array_columns = []
         else:
             array_columns = [col_name[0] for col_name in array_columns_]

--- a/es/elastic/sqlalchemy.py
+++ b/es/elastic/sqlalchemy.py
@@ -38,6 +38,12 @@ class ESDialect(basesqlalchemy.BaseESDialect):
         # return a list of table names exclude hidden and empty indexes
         return [table.name for table in result if table.name[0] != "."]
 
+    def get_view_names(self, connection, schema=None, **kwargs) -> List[str]:
+        query = "SHOW VALID_VIEWS"
+        result = connection.execute(query)
+        # return a list of view names (ES aliases) exclude hidden and empty indexes
+        return [table.name for table in result if table.name[0] != "."]
+
     def get_columns(self, connection, table_name, schema=None, **kwargs):
         query = f'SHOW COLUMNS FROM "{table_name}"'
         # A bit of an hack this cmd does not exist on ES

--- a/es/opendistro/api.py
+++ b/es/opendistro/api.py
@@ -125,7 +125,7 @@ class Cursor(BaseCursor):
     custom_sql_to_method = {
         "show valid_tables": "get_valid_table_names",
         "show valid_views": "get_valid_view_names",
-        "select 1": "get_valid_select_one"
+        "select 1": "get_valid_select_one",
     }
 
     def __init__(self, url: str, es: Elasticsearch, **kwargs: Any) -> None:

--- a/es/opendistro/api.py
+++ b/es/opendistro/api.py
@@ -234,10 +234,10 @@ class Cursor(BaseCursor):
         if operation == "SHOW VALID_TABLES":
             return self.get_valid_table_names()
 
-        if operation == "SHOW VALID_VIEWS":
+        elif operation == "SHOW VALID_VIEWS":
             return self.get_valid_view_names()
 
-        if operation.lower() == "select 1":
+        elif operation.lower() == "select 1":
             return self.get_valid_select_one()
 
         re_table_name = re.match("SHOW VALID_COLUMNS FROM (.*)", operation)

--- a/es/opendistro/api.py
+++ b/es/opendistro/api.py
@@ -253,7 +253,7 @@ class Cursor(BaseCursor):
     @check_closed
     def execute(
         self, operation: str, parameters: Optional[Dict[str, Any]] = None
-    ) -> "Cursor":
+    ) -> "BaseCursor":
         cursor = self.custom_sql_to_method_dispatcher(operation)
         if cursor:
             return cursor

--- a/es/opendistro/sqlalchemy.py
+++ b/es/opendistro/sqlalchemy.py
@@ -39,6 +39,13 @@ class ESDialect(basesqlalchemy.BaseESDialect):
         # return a list of table names exclude hidden and empty indexes
         return [table.TABLE_NAME for table in result if table.TABLE_NAME[0] != "."]
 
+    def get_view_names(self, connection, schema=None, **kwargs):
+        # custom builtin query
+        query = "SHOW VALID_VIEWS"
+        result = connection.execute(query)
+        # return a list of table names exclude hidden and empty indexes
+        return [table.VIEW_NAME for table in result if table.VIEW_NAME[0] != "."]
+
     def get_columns(self, connection, table_name, schema=None, **kwargs):
         # custom builtin query
         query = f"SHOW VALID_COLUMNS FROM {table_name}"

--- a/es/opendistro/sqlalchemy.py
+++ b/es/opendistro/sqlalchemy.py
@@ -1,13 +1,10 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import logging
-from typing import List
+from types import ModuleType
+from typing import Any, Dict, List, Optional
 
 from es import basesqlalchemy
 import es.opendistro
+from sqlalchemy.engine import Connection
 
 logger = logging.getLogger(__name__)
 
@@ -29,24 +26,34 @@ class ESDialect(basesqlalchemy.BaseESDialect):
     type_compiler = ESTypeCompiler
 
     @classmethod
-    def dbapi(cls):
+    def dbapi(cls) -> ModuleType:
         return es.opendistro
 
-    def get_table_names(self, connection, schema=None, **kwargs) -> List[str]:
+    def get_table_names(
+        self, connection: Connection, schema: Optional[str] = None, **kwargs: Any
+    ) -> List[str]:
         # custom builtin query
         query = "SHOW VALID_TABLES"
         result = connection.execute(query)
         # return a list of table names exclude hidden and empty indexes
         return [table.TABLE_NAME for table in result if table.TABLE_NAME[0] != "."]
 
-    def get_view_names(self, connection, schema=None, **kwargs):
+    def get_view_names(
+        self, connection: Connection, schema: Optional[str] = None, **kwargs: Any
+    ) -> List[str]:
         # custom builtin query
         query = "SHOW VALID_VIEWS"
         result = connection.execute(query)
         # return a list of table names exclude hidden and empty indexes
         return [table.VIEW_NAME for table in result if table.VIEW_NAME[0] != "."]
 
-    def get_columns(self, connection, table_name, schema=None, **kwargs):
+    def get_columns(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: Optional[str] = None,
+        **kwargs: Any,
+    ) -> List[Dict[str, Any]]:
         # custom builtin query
         query = f"SHOW VALID_COLUMNS FROM {table_name}"
 

--- a/es/tests/fixtures/fixtures.py
+++ b/es/tests/fixtures/fixtures.py
@@ -72,7 +72,7 @@ data1_columns = [
 
 
 def import_file_to_es(
-    base_url, data_path, index_name, mappings_path: Optional[str] = None
+    base_url: str, data_path: str, index_name: str, mappings_path: Optional[str] = None
 ) -> None:
 
     with open(data_path, "r") as fd_data:
@@ -103,7 +103,7 @@ def set_index_settings(
     es.indices.create(index=index_name, ignore=400, body=body)
 
 
-def delete_index(base_url, index_name):
+def delete_index(base_url, index_name: str) -> None:
     es = Elasticsearch(base_url, verify_certs=False)
     try:
         es.delete_by_query(index=index_name, body={"query": {"match_all": {}}})
@@ -111,12 +111,28 @@ def delete_index(base_url, index_name):
         return
 
 
-def import_flights(base_url):
+def delete_alias(base_url, alias_name: str, index_name: str) -> None:
+    es = Elasticsearch(base_url, verify_certs=False)
+    try:
+        es.indices.delete_alias(index=index_name, name=alias_name)
+    except NotFoundError:
+        return
+
+
+def create_alias(base_url, alias_name: str, index_name: str) -> None:
+    es = Elasticsearch(base_url, verify_certs=False)
+    try:
+        es.indices.put_alias(index=index_name, name=alias_name)
+    except NotFoundError:
+        return
+
+
+def import_flights(base_url: str) -> None:
     path = os.path.join(os.path.dirname(__file__), "flights.json")
     import_file_to_es(base_url, path, "flights")
 
 
-def import_data1(base_url):
+def import_data1(base_url: str) -> None:
     data_path = os.path.join(os.path.dirname(__file__), "data1.json")
     mappings_path = os.path.join(os.path.dirname(__file__), "data1_mappings.json")
 

--- a/es/tests/test_0_fixtures.py
+++ b/es/tests/test_0_fixtures.py
@@ -2,6 +2,8 @@ import os
 import unittest
 
 from .fixtures.fixtures import (
+    create_alias,
+    delete_alias,
     delete_index,
     import_data1,
     import_empty_index,
@@ -26,3 +28,8 @@ class TestData(unittest.TestCase):
     def test_data_empty_index(self):
         delete_index(self.base_url, "empty_index")
         import_empty_index(self.base_url)
+
+    def test_alias_to_data1(self):
+        alias_name = "alias_to_data1"
+        delete_alias(self.base_url, alias_name, "data1")
+        create_alias(self.base_url, alias_name, "data1")

--- a/es/tests/test_0_fixtures.py
+++ b/es/tests/test_0_fixtures.py
@@ -17,19 +17,19 @@ class TestData(unittest.TestCase):
     def setUp(self):
         self.base_url = os.environ.get("ES_URI", BASE_URL)
 
-    def test_data_flights(self):
+    def test_1_data_flights(self):
         delete_index(self.base_url, "flights")
         import_flights(self.base_url)
 
-    def test_data_data1(self):
+    def test_2_data_data1(self):
         delete_index(self.base_url, "data1")
         import_data1(self.base_url)
 
-    def test_data_empty_index(self):
+    def test_3_data_empty_index(self):
         delete_index(self.base_url, "empty_index")
         import_empty_index(self.base_url)
 
-    def test_alias_to_data1(self):
+    def test_4_alias_to_data1(self):
         alias_name = "alias_to_data1"
         delete_alias(self.base_url, alias_name, "data1")
         create_alias(self.base_url, alias_name, "data1")

--- a/es/tests/test_sqlalchemy.py
+++ b/es/tests/test_sqlalchemy.py
@@ -102,8 +102,6 @@ class TestSQLAlchemy(unittest.TestCase):
         """
         SQLAlchemy: Test get_view_names to verify alias is returned
         """
-        if self.driver_name != "odelasticsearch":
-            return
         inspector = Inspector.from_engine(self.engine)
         views = inspector.get_view_names("default1")
         self.assertEqual(views, ["alias_to_data1"])

--- a/es/tests/test_sqlalchemy.py
+++ b/es/tests/test_sqlalchemy.py
@@ -6,6 +6,7 @@ from es.exceptions import DatabaseError
 from es.tests.fixtures.fixtures import data1_columns, flights_columns
 from sqlalchemy import func, inspect, select
 from sqlalchemy.engine import create_engine
+from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.schema import MetaData, Table
@@ -96,6 +97,27 @@ class TestSQLAlchemy(unittest.TestCase):
         metadata.reflect(bind=self.engine)
         source_cols = [c.name for c in metadata.tables["data1"].c]
         self.assertEqual(data1_columns, source_cols)
+
+    def test_get_view_names(self):
+        """
+        SQLAlchemy: Test get_view_names to verify alias is returned
+        """
+        if self.driver_name != "odelasticsearch":
+            return
+        inspector = Inspector.from_engine(self.engine)
+        views = inspector.get_view_names("default1")
+        self.assertEqual(views, ["alias_to_data1"])
+
+    def test_get_alias_columns(self):
+        """
+        SQLAlchemy: Test get_view_names to verify alias is returned
+        """
+        inspector = Inspector.from_engine(self.engine)
+        alias_columns = inspector.get_columns("alias_to_data1")
+        index_columns = inspector.get_columns("data1")
+        for i, alias_column in enumerate(alias_columns):
+            self.assertEqual(alias_column["name"], index_columns[i]["name"])
+            self.assertEqual(type(alias_column["type"]), type(index_columns[i]["type"]))
 
     def test_get_columns_exclude_geo_point(self):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,15 @@ disallow_any_generics = true
 ignore_missing_imports = true
 no_implicit_optional = true
 warn_unused_ignores = true
+
+[mypy-es.elastic.*]
+check_untyped_defs = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+warn_unused_ignores = false
+
+[mypy-es.opendistro.*]
+check_untyped_defs = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+warn_unused_ignores = false


### PR DESCRIPTION
Adds alias support for opendistro. On the current opendistro SQL endpoint indices with dots are not supported, yet their very common, using aliases on these cases solves the problem

- Also splits views from tables on plain elasticsearch from Elastic

- Adds full type annotations