### PR TITLE
fix: support elasticsearch > 7.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           discovery.type: single-node
         ports:
-          - 39200:39200
+          - 39200:9200
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,12 @@ jobs:
       - name: Run tests on Elasticsearch
         run: |
           export ES_URI="http://localhost:9200"
+          export ES_PORT=9200
           nosetests -v --with-coverage --cover-package=es es.tests
       - name: Run tests on Elasticsearch 7.10.X
         run: |
           export ES_URI="http://localhost:39200"
+          export ES_PORT=39200
           nosetests -v --with-coverage --cover-package=es es.tests
       - name: Run tests on Opendistro
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
           discovery.type: single-node
         ports:
           - 29200:9200
+      elasticsearch_7_10:
+        image: elasticsearch:7.10.1
+        env:
+          discovery.type: single-node
+        ports:
+          - 39200:39200
 
     steps:
       - uses: actions/checkout@v2
@@ -76,6 +82,10 @@ jobs:
       - name: Run tests on Elasticsearch
         run: |
           export ES_URI="http://localhost:9200"
+          nosetests -v --with-coverage --cover-package=es es.tests
+      - name: Run tests on Elasticsearch 7.10.X
+        run: |
+          export ES_URI="http://localhost:39200"
           nosetests -v --with-coverage --cover-package=es es.tests
       - name: Run tests on Opendistro
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   elasticsearch:
-    image: elasticsearch:7.3.2
+    image: elasticsearch:7.10.1
     env_file: .env
     ports:
       - 9200:9200
@@ -22,7 +22,8 @@ services:
       - 29300:9300
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.3.2
+    image: docker.elastic.co/kibana/kibana:7.10.1
     env_file: .env
     ports:
       - 5601:5601
+

--- a/es/elastic/api.py
+++ b/es/elastic/api.py
@@ -12,6 +12,7 @@ from es.baseapi import (
     get_description_from_columns,
     Type,
 )
+from packaging import version
 
 
 def connect(
@@ -115,6 +116,11 @@ class Cursor(BaseCursor):
         return self
 
     def get_valid_table_names(self) -> "Cursor":
+        # Get the ES cluster version. Since 7.10 the table column name changed #52
+        cluster_info = self.es.info()
+        cluster_version = version.parse(cluster_info["version"]["number"])
+        if cluster_version >= version.parse("7.10.0"):
+            return self.get_valid_table_view_names("TABLE")
         return self.get_valid_table_view_names("BASE TABLE")
 
     def get_valid_view_names(self) -> "Cursor":

--- a/es/elastic/api.py
+++ b/es/elastic/api.py
@@ -120,7 +120,6 @@ class Cursor(BaseCursor):
         cluster_info = self.es.info()
         cluster_version = version.parse(cluster_info["version"]["number"])
         if cluster_version >= version.parse("7.10.0"):
-            raise Exception("CENA")
             return self.get_valid_table_view_names("TABLE")
         return self.get_valid_table_view_names("BASE TABLE")
 

--- a/es/elastic/api.py
+++ b/es/elastic/api.py
@@ -120,6 +120,7 @@ class Cursor(BaseCursor):
         cluster_info = self.es.info()
         cluster_version = version.parse(cluster_info["version"]["number"])
         if cluster_version >= version.parse("7.10.0"):
+            raise Exception("CENA")
             return self.get_valid_table_view_names("TABLE")
         return self.get_valid_table_view_names("BASE TABLE")
 


### PR DESCRIPTION
Solves #52

Since Elasticsearch version 7.10.0 `SHOW TABLES` table column name change from `BASE TABLE` to `TABLE`.
This PR supports both versions, before fetching table metadata makes a call for fetch the cluster info