### PR TITLE
fix: missing time type

### DIFF
--- a/es/baseapi.py
+++ b/es/baseapi.py
@@ -83,6 +83,7 @@ def get_type(data_type) -> int:
         "interval_day": Type.STRING,
         "interval_month": Type.STRING,
         "interval_year": Type.STRING,
+        "time": Type.STRING,
     }
     return type_map[data_type.lower()]
 


### PR DESCRIPTION
Currently, Executing this sql will throw exception.
```sql
SELECT CURTIME() AS result
```
```
File "<string>", line 1, in <module>
  File "/home/maltoze/repos/superset/venv/lib/python3.7/site-packages/es/baseapi.py", line 37, in wrap
    return f(self, *args, **kwargs)
  File "/home/maltoze/repos/superset/venv/lib/python3.7/site-packages/es/elastic/api.py", line 145, in execute
    self.description = get_description_from_columns(columns)
  File "/home/maltoze/repos/superset/venv/lib/python3.7/site-packages/es/baseapi.py", line 105, in get_description_from_columns
    for column in columns
  File "/home/maltoze/repos/superset/venv/lib/python3.7/site-packages/es/baseapi.py", line 105, in <listcomp>
    for column in columns
  File "/home/maltoze/repos/superset/venv/lib/python3.7/site-packages/es/baseapi.py", line 87, in get_type
    return type_map[data_type.lower()]
KeyError: 'time'
```
This will fix it.