### PR TITLE
release: 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Change log
 
+### 0.2.4
+
+- fix: Bump urllib3 from 1.25.6 to 1.26.5 (#64) [dependabot]
+- fix: missing time type (#60) [maltoze]
+
 ### 0.2.3
 
 - fix: missing dependency, packaging [Daniel Vaz Gaspar]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 from setuptools import find_packages, setup
 
-VERSION = "0.2.3"
+VERSION = "0.2.4"
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 with io.open("README.md", "r", encoding="utf-8") as f:


### PR DESCRIPTION
Release: 0.2.4

```
- fix: Bump urllib3 from 1.25.6 to 1.26.5 (#64) [dependabot]
- fix: missing time type (#60) [maltoze]
```
