### PR TITLE
update has_table to accept view or table

### DIFF
--- a/es/basesqlalchemy.py
+++ b/es/basesqlalchemy.py
@@ -144,7 +144,7 @@ class BaseESDialect(default.DefaultDialect):
         return [DEFAULT_SCHEMA]
 
     def has_table(self, connection, table_name, schema=None):
-        return table_name in self.get_table_names(connection, schema)
+        pass  # pragma: no cover
 
     def get_table_names(self, connection, schema=None, **kwargs) -> List[str]:
         pass  # pragma: no cover

--- a/es/elastic/sqlalchemy.py
+++ b/es/elastic/sqlalchemy.py
@@ -29,6 +29,14 @@ class ESDialect(basesqlalchemy.BaseESDialect):
     def dbapi(cls) -> ModuleType:
         return es.elastic
 
+    def has_table(
+        self, connection: Connection, table_name: str, schema: Optional[str] = None, **kwargs: Any
+    ) -> bool:
+        query = "SHOW TABLES"
+        result = connection.execute(query)
+        table_names = [table.name for table in result if table.name[0] != "."]
+        return table_name in table_names
+
     def get_table_names(
         self, connection: Connection, schema: Optional[str] = None, **kwargs: Any
     ) -> List[str]:

--- a/es/opendistro/sqlalchemy.py
+++ b/es/opendistro/sqlalchemy.py
@@ -29,6 +29,14 @@ class ESDialect(basesqlalchemy.BaseESDialect):
     def dbapi(cls) -> ModuleType:
         return es.opendistro
 
+    def has_table(
+        self, connection: Connection, table_name: str, schema: Optional[str] = None, **kwargs: Any
+    ) -> bool:
+        query = "SHOW TABLES"
+        result = connection.execute(query)
+        table_names = [table.name for table in result if table.name[0] != "."]
+        return table_name in table_names
+
     def get_table_names(
         self, connection: Connection, schema: Optional[str] = None, **kwargs: Any
     ) -> List[str]:

--- a/es/tests/test_sqlalchemy.py
+++ b/es/tests/test_sqlalchemy.py
@@ -86,6 +86,7 @@ class TestSQLAlchemy(unittest.TestCase):
         SQLAlchemy: Test has_table
         """
         self.assertTrue(self.engine.has_table("flights"))
+        self.assertTrue(self.engine.has_table("alias_to_data1"))
 
     def test_get_schema_names(self):
         """


### PR DESCRIPTION
When trying to add a view as a data source in superset, it will error out because has_table only return true for "BASE TABLE" type. This was confirmed when looking at the other dialects that return true for views and tables.