### PR TITLE
release: 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Change log
 
+### 0.2.6
+
+- fix: pin elasticsearch-py bellow 7.14 (#71)
+- feat(query): add time_zone param (#69)
+
 ### 0.2.5
 
 - fix: Bump packaging [Beto Dealmeida]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### 0.2.6
 
-- fix: pin elasticsearch-py bellow 7.14 (#71)
-- feat(query): add time_zone param (#69)
+- fix: pin elasticsearch-py bellow 7.14 (#71) [Daniel Vaz Gaspar]
+- feat(query): add time_zone param (#69) [aniaan]
 
 ### 0.2.5
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 from setuptools import find_packages, setup
 
-VERSION = "0.2.5"
+VERSION = "0.2.6"
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 with io.open("README.md", "r", encoding="utf-8") as f:


### PR DESCRIPTION
Release 0.2.6

changelog:

- fix: pin elasticsearch-py bellow 7.14 (#71)
- feat(query): add time_zone param (#69)
