### PR TITLE
fix: unpin packaging dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,15 @@
 #
 #    pip-compile
 #
+certifi==2021.10.8
+    # via elasticsearch
 elasticsearch==7.13.4
     # via elasticsearch-dbapi (setup.py)
 greenlet==1.0.0
     # via sqlalchemy
 importlib-metadata==4.0.0
     # via sqlalchemy
-packaging==20.9
+packaging==21.3
     # via elasticsearch-dbapi (setup.py)
 pyparsing==2.4.7
     # via packaging

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
             "odelasticsearch.https = es.opendistro.sqlalchemy:ESHTTPSDialect",
         ]
     },
-    install_requires=["elasticsearch>7, <7.14", "packaging==21.0", "sqlalchemy"],
+    install_requires=["elasticsearch>7, <7.14", "packaging>=21.0, <22.0", "sqlalchemy"],
     extras_require={"opendistro": ["requests_aws4auth", "boto3"]},
     author="Preset Inc.",
     author_email="daniel@preset.io",


### PR DESCRIPTION
Removes pinned packaging dependency, introduced here: https://github.com/preset-io/elasticsearch-dbapi/pull/67

Fixes: #76 