### PR TITLE
tests: add test case for `test_execute_empty_result`

### DIFF
--- a/es/tests/test_dbapi.py
+++ b/es/tests/test_dbapi.py
@@ -112,6 +112,11 @@ class TestDBAPI(unittest.TestCase):
         ).fetchall()
         self.assertEquals(len(rows), 0)
 
+        count = self.cursor.execute(
+            "select Carrier from flights where Carrier='NORESULT'"
+        ).rowcount
+        self.assertEquals(count, 0)
+
     def test_execute_rowcount(self):
         """
         DBAPI: Test execute and rowcount


### PR DESCRIPTION
added a test case where the `rowcount` returns 0 when there are no results
https://github.com/preset-io/elasticsearch-dbapi/blob/7e48e57367c3b745bc640fc84d4aca4833a099ed/es/baseapi.py#L224

https://github.com/preset-io/elasticsearch-dbapi/blob/7e48e57367c3b745bc640fc84d4aca4833a099ed/es/baseapi.py#L220-#L224