### PR TITLE
Fix missing docs.count

### DIFF
--- a/es/elastic/api.py
+++ b/es/elastic/api.py
@@ -120,9 +120,13 @@ class Cursor(BaseCursor):
             for item in response:
                 # First column is TABLE_NAME
                 if item["index"] == self._get_value_for_col_name(result, "name"):
-                    if int(item["docs.count"]) == 0:
-                        is_empty = True
-                        break
+                    try:
+                        if int(item["docs.count"]) == 0:
+                            is_empty = True
+                            break
+                    except Exception as ex:
+                       is_empty = True
+                       break
             if (
                 not is_empty
                 and self._get_value_for_col_name(result, "type") == type_filter


### PR DESCRIPTION
Our Elastic cluster has a number of indexes that don't return this value.  The indexes do appear to be empty as well from looking at the indexes in elastic.  This is the for example is what is in item:
{'health': 'green', 'status': 'open', 'index': '<my index>', 'uuid': 't_w0eDA9SXS8CGYhYtXhfg', 'pri': '1', 'rep': '1', 'docs.count': None, 'docs.deleted': None, 'store.size': None, 'pri.store.size': None}