### PR TITLE
chore: upgrade dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-black==19.3b0
-coverage==4.5.3
-flake8==3.7.7
-flake8-commas==2.0.0
+black==22.3.0
+coverage==6.3.2
+flake8==4.0.1
+flake8-commas==2.1.0
 flake8-import-order==0.18.1
 nose==1.3.7
 pip-tools==3.6.0


### PR DESCRIPTION
black was failing with:

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.12/x64/bin/black", line [8](https://github.com/preset-io/elasticsearch-dbapi/runs/6084566315?check_suite_focus=true#step:5:8), in <module>
    sys.exit(patched_main())
  File "/opt/hostedtoolcache/Python/3.7.[12](https://github.com/preset-io/elasticsearch-dbapi/runs/6084566315?check_suite_focus=true#step:5:12)/x64/lib/python3.7/site-packages/black.py", line 3753, in patched_main
    patch_click()
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/black.py", line 3742, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/click/__init__.py)
Error: Process completed with exit code 1.
``` 