### PR TITLE
fix(opendistro): quote with backtick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change log
 
+### Next
+
+- fix: OpenDistro dialect quotes properly with backticks now (#99) [Beto Dealmeida]
+
 ### 0.2.9
 
 - fix: remove six dependency (#84) [Daniel Vaz Gaspar]

--- a/es/opendistro/sqlalchemy.py
+++ b/es/opendistro/sqlalchemy.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 from es import basesqlalchemy
 import es.opendistro
 from sqlalchemy.engine import Connection
+from sqlalchemy.sql import compiler
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +18,13 @@ class ESTypeCompiler(basesqlalchemy.BaseESTypeCompiler):  # pragma: no cover
     pass
 
 
+class ESTypeIdentifierPreparer(compiler.IdentifierPreparer):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+
+        self.initial_quote = self.final_quote = "`"
+
+
 class ESDialect(basesqlalchemy.BaseESDialect):
 
     name = "odelasticsearch"
@@ -24,6 +32,7 @@ class ESDialect(basesqlalchemy.BaseESDialect):
     driver = "rest"
     statement_compiler = ESCompiler
     type_compiler = ESTypeCompiler
+    preparer = ESTypeIdentifierPreparer
 
     @classmethod
     def dbapi(cls) -> ModuleType:

--- a/es/tests/test_sqlalchemy.py
+++ b/es/tests/test_sqlalchemy.py
@@ -3,7 +3,9 @@ from typing import List
 import unittest
 from unittest.mock import Mock, patch
 
+from es.elastic.sqlalchemy import ESDialect as ElasticDialect
 from es.exceptions import DatabaseError
+from es.opendistro.sqlalchemy import ESDialect as OpenDistroDialect
 from es.tests.fixtures.fixtures import data1_columns, flights_columns
 from sqlalchemy import func, inspect, select
 from sqlalchemy.engine import create_engine
@@ -325,3 +327,21 @@ class TestSQLAlchemy(unittest.TestCase):
             conn = self.engine.raw_connection()
             with self.assertRaises(DatabaseError):
                 self.engine.dialect.do_ping(conn)
+
+
+class TestQuote(unittest.TestCase):
+    """
+    Test quoting identifiers in ES and OD.
+    """
+
+    def test_elastic(self) -> None:
+        assert (
+            ElasticDialect.preparer(dialect=ElasticDialect()).quote("DATE(123)")
+            == '"DATE(123)"'
+        )
+
+    def test_opendistro(self) -> None:
+        assert (
+            OpenDistroDialect.preparer(dialect=OpenDistroDialect()).quote("DATE(123)")
+            == "`DATE(123)`"
+        )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ readme_renderer==24.0
 mypy==0.790
 requests-aws4auth==1.0.1
 boto3==1.16.63
+pytest==7.2.1


### PR DESCRIPTION
OpenDistro uses backticks for quoting identifiers: https://opendistro.github.io/for-elasticsearch-docs/docs/ppl/identifiers/#delimited-identifiers