### PR TITLE
fix(OpenSearch): Support removing `default` from query

### DIFF
--- a/es/opendistro/api.py
+++ b/es/opendistro/api.py
@@ -304,8 +304,8 @@ class Cursor(BaseCursor):
         return self
 
     def sanitize_query(self, query: str) -> str:
-        query = query.replace('"', "")
-        query = query.replace("  ", " ")
-        query = query.replace("\n", " ")
-        # remove dummy schema from queries
-        return query.replace(f"FROM {DEFAULT_SCHEMA}.", "FROM ")
+        """
+        Removes dummy schema from queries
+        """
+        query.replace(f'FROM "{DEFAULT_SCHEMA}".', "FROM ")
+        return query.replace(f"FROM `{DEFAULT_SCHEMA}`.", "FROM ")

--- a/es/opendistro/api.py
+++ b/es/opendistro/api.py
@@ -307,5 +307,5 @@ class Cursor(BaseCursor):
         """
         Removes dummy schema from queries
         """
-        query.replace(f'FROM "{DEFAULT_SCHEMA}".', "FROM ")
+        query = query.replace(f'FROM "{DEFAULT_SCHEMA}".', "FROM ")
         return query.replace(f"FROM `{DEFAULT_SCHEMA}`.", "FROM ")

--- a/es/tests/test_opendistro_sanitize_query.py
+++ b/es/tests/test_opendistro_sanitize_query.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import Mock
+
+from es.opendistro.api import Cursor
+
+
+class TestSanitizeQuery(unittest.TestCase):
+    """Unit tests for Cursor.sanitize_query — no live cluster required."""
+
+    def _sanitize(self, query: str) -> str:
+        return Cursor.sanitize_query(Mock(spec=Cursor), query)
+
+    def test_strips_double_quoted_default_schema(self):
+        self.assertEqual(
+            self._sanitize('SELECT a FROM "default".flights'),
+            "SELECT a FROM flights",
+        )
+
+    def test_strips_backtick_quoted_default_schema(self):
+        self.assertEqual(
+            self._sanitize("SELECT a FROM `default`.flights"),
+            "SELECT a FROM flights",
+        )
+
+    def test_no_match_is_unchanged(self):
+        query = "SELECT a FROM flights WHERE Carrier = 'Kibana Airlines'"
+        self.assertEqual(self._sanitize(query), query)
+
+    def test_does_not_strip_unrelated_quoted_default_token(self):
+        query = "SELECT 'default' AS label FROM flights"
+        self.assertEqual(self._sanitize(query), query)
+
+    def test_does_not_strip_identifier_delimiters(self):
+        query = "SELECT count(*) as `my test` from foo"
+        self.assertEqual(self._sanitize(query), query)


### PR DESCRIPTION
The official identifier delimiter for OpenSearch is backticks (`` ` ``). The current `sanitize_query` was able to remove the schema name when using double quotes (`"default"`) but would not remove it when using backticks (`` `default` ``).

This PR updates the logic to still catch `"default"` which is supported in newer versions but also catch `` `default` `` which is the official delimiter. 

This should unblock Superset use-cases with metrics named like `my test` for example.

The PR also preserves double spaces and line breaks as these should be supported with current OpenSearch versions.