### PR TITLE
Follow the SQL cursor across pages instead of returning only the first

### DIFF
--- a/es/elastic/api.py
+++ b/es/elastic/api.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from typing import Any, cast, Dict, List, Optional, Tuple
 
@@ -13,6 +14,8 @@ from es.baseapi import (
     Type,
 )
 from packaging import version
+
+logger = logging.getLogger(__name__)
 
 
 def connect(
@@ -166,16 +169,77 @@ class Cursor(BaseCursor):
 
         query = apply_parameters(operation, parameters)
         results = self.elastic_query(query)
-        # We need a list of tuples
-        rows = [tuple(row) for row in results.get("rows", [])]
         columns = results.get("columns")
         if not columns:
             raise exceptions.DataError(
                 "Missing columns field, maybe it's an opendistro sql ep"
             )
-        self._results = rows
         self.description = get_description_from_columns(columns)
+
+        # We need a list of tuples
+        rows = [tuple(row) for row in results.get("rows", [])]
+
+        # Elasticsearch's SQL API only returns up to `fetch_size` rows per
+        # request. A larger result set comes back with a `cursor` that must
+        # be followed to fetch subsequent pages, or later rows are silently
+        # dropped. See:
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-pagination.html
+        es_cursor = results.get("cursor")
+        try:
+            while es_cursor:
+                results = self.elastic_cursor_query(es_cursor)
+                rows.extend(tuple(row) for row in results.get("rows", []))
+                es_cursor = results.get("cursor")
+        finally:
+            # A cursor is only still open here if we're exiting via an
+            # exception raised mid-pagination; ES returns no cursor on the
+            # final page, so on a normal, fully-consumed loop there's
+            # nothing left to close server-side.
+            if es_cursor:
+                self.close_elastic_cursor(es_cursor)
+
+        self._results = rows
         return self
+
+    def elastic_cursor_query(self, cursor: str) -> Dict[str, Any]:
+        """
+        Follow an Elasticsearch SQL cursor to fetch the next page of a
+        result set.
+        """
+        path = f"/{self.sql_path}/"
+        kwargs: Dict[str, Any] = {"body": {"cursor": cursor}}
+        if isinstance(self.es, Elasticsearch):
+            kwargs["headers"] = {"Content-Type": "application/json"}
+        try:
+            response = self.es.transport.perform_request("POST", path, **kwargs)
+        except es_exceptions.ConnectionError:
+            raise exceptions.OperationalError(
+                "Error connecting to Elasticsearch/OpenSearch"
+            )
+        except es_exceptions.RequestError as ex:
+            raise exceptions.ProgrammingError(f"Error ({ex.error}): {ex.info}")
+        if isinstance(response, bool):
+            raise exceptions.UnexpectedRequestResponse()
+        if "error" in response:
+            raise exceptions.ProgrammingError(
+                f"({response['error']['reason']}): {response['error']['details']}"
+            )
+        return response
+
+    def close_elastic_cursor(self, cursor: str) -> None:
+        """
+        Release server-side resources held by an open Elasticsearch SQL
+        cursor. Best-effort: a failure here is logged, not raised, so it
+        doesn't mask the original query result or error.
+        """
+        path = f"/{self.sql_path}/close"
+        kwargs: Dict[str, Any] = {"body": {"cursor": cursor}}
+        if isinstance(self.es, Elasticsearch):
+            kwargs["headers"] = {"Content-Type": "application/json"}
+        try:
+            self.es.transport.perform_request("POST", path, **kwargs)
+        except Exception:
+            logger.warning("Failed to close Elasticsearch SQL cursor", exc_info=True)
 
     def get_array_type_columns(self, table_name: str) -> "Cursor":
         """

--- a/es/tests/test_cursor_pagination.py
+++ b/es/tests/test_cursor_pagination.py
@@ -1,0 +1,115 @@
+"""
+Unit tests for Elasticsearch SQL cursor pagination in ``es.elastic.api``.
+
+Unlike the rest of ``es/tests``, these tests mock the transport layer
+instead of requiring a live Elasticsearch/OpenSearch cluster, so they can
+run fast and standalone. They exist specifically to pin down the
+cursor-following behavior added to ``Cursor.execute``: previously, only
+the first page of a query's results (bounded by ``fetch_size``) was ever
+returned, silently dropping any additional rows.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from es.elastic.api import connect
+
+
+class TestCursorPagination(unittest.TestCase):
+    def setUp(self):
+        self.conn = connect(host="localhost")
+        self.cursor = self.conn.cursor()
+
+    def test_execute_follows_cursor_across_pages(self):
+        """
+        A response that includes a ``cursor`` field must not stop after
+        the first page: subsequent pages should be fetched and their rows
+        appended, until a response with no ``cursor`` is reached.
+        """
+        responses = [
+            {
+                "columns": [{"name": "a", "type": "long"}],
+                "rows": [[1], [2]],
+                "cursor": "page-2-cursor",
+            },
+            {"rows": [[3], [4]], "cursor": "page-3-cursor"},
+            {"rows": [[5]]},  # final page: no cursor
+        ]
+
+        with patch.object(
+            self.cursor.es.transport, "perform_request", side_effect=responses
+        ) as mock_request:
+            self.cursor.execute("select a from some_table")
+
+        self.assertEqual(self.cursor.fetchall(), [(1,), (2,), (3,), (4,), (5,)])
+        self.assertEqual(mock_request.call_count, 3)
+
+        # first call is the initial query; the rest follow the cursor
+        first_call = mock_request.call_args_list[0]
+        self.assertEqual(first_call.args[0], "POST")
+        self.assertIn("query", first_call.kwargs["body"])
+
+        second_call = mock_request.call_args_list[1]
+        self.assertEqual(second_call.kwargs["body"], {"cursor": "page-2-cursor"})
+
+        third_call = mock_request.call_args_list[2]
+        self.assertEqual(third_call.kwargs["body"], {"cursor": "page-3-cursor"})
+
+    def test_execute_single_page_unaffected(self):
+        """
+        A response with no ``cursor`` at all (result fits in one page)
+        should behave exactly as before: a single request, no pagination
+        follow-up, no close call.
+        """
+        responses = [
+            {"columns": [{"name": "a", "type": "long"}], "rows": [[1], [2]]},
+        ]
+
+        with patch.object(
+            self.cursor.es.transport, "perform_request", side_effect=responses
+        ) as mock_request:
+            self.cursor.execute("select a from some_table")
+
+        self.assertEqual(self.cursor.fetchall(), [(1,), (2,)])
+        self.assertEqual(mock_request.call_count, 1)
+
+    def test_cursor_closed_on_mid_pagination_error(self):
+        """
+        If a follow-up page request raises mid-pagination, the still-open
+        cursor must be closed (best-effort) rather than leaked, and the
+        original exception should still propagate.
+        """
+        from elasticsearch import exceptions as es_exceptions
+
+        first_response = {
+            "columns": [{"name": "a", "type": "long"}],
+            "rows": [[1]],
+            "cursor": "page-2-cursor",
+        }
+
+        def side_effect(method, path, **kwargs):
+            if path.endswith("/close"):
+                return {}
+            if kwargs.get("body", {}).get("cursor") == "page-2-cursor":
+                raise es_exceptions.ConnectionError("boom")
+            return first_response
+
+        with patch.object(
+            self.cursor.es.transport, "perform_request", side_effect=side_effect
+        ) as mock_request:
+            from es.exceptions import OperationalError
+
+            with self.assertRaises(OperationalError):
+                self.cursor.execute("select a from some_table")
+
+        close_calls = [
+            call
+            for call in mock_request.call_args_list
+            if call.args[1].endswith("/close")
+        ]
+        self.assertEqual(len(close_calls), 1)
+        self.assertEqual(close_calls[0].kwargs["body"], {"cursor": "page-2-cursor"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/es/tests/test_dbapi.py
+++ b/es/tests/test_dbapi.py
@@ -69,6 +69,28 @@ class TestDBAPI(unittest.TestCase):
         rows = self.cursor.execute("select Carrier from flights").fetchall()
         self.assertEqual(len(rows), 31)
 
+    def test_execute_fetchall_paginates_past_fetch_size(self):
+        """
+        DBAPI: A result set larger than fetch_size must be fully returned by
+        following the Elasticsearch SQL cursor across pages, not just the
+        first page.
+        """
+        if self.driver_name != "elasticsearch":
+            self.skipTest("SQL cursor pagination is Elasticsearch-specific")
+        conn = self.connect_func(
+            host=self.host,
+            port=self.port,
+            scheme=self.scheme,
+            verify_certs=self.verify_certs,
+            user=self.user,
+            password=self.password,
+            fetch_size=5,
+        )
+        cursor = conn.cursor()
+        rows = cursor.execute("select Carrier from flights").fetchall()
+        self.assertEqual(len(rows), 31)
+        conn.close()
+
     def test_execute_on_connect(self):
         """
         DBAPI: Test execute, fetchall on connect


### PR DESCRIPTION
### Summary

`Cursor.execute()` sends one POST to `_sql` with `fetch_size`, takes `rows`/`columns` from that single response, and returns. Elasticsearch's SQL API includes a `cursor` field in the response whenever more rows remain past `fetch_size` — this driver never follows it. Any result set larger than `fetch_size` silently loses every row past the first page, with no error raised.

Fixes #88.

### What changed

`Cursor.execute()` now loops on the `cursor` field the initial (and each subsequent) response returns, POSTing `{"cursor": ...}` back to the same `_sql` endpoint until a response comes back with no cursor (the documented signal that the result set is exhausted: https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-pagination.html). Rows from every page are concatenated into `self._results`, so `fetchone`/`fetchmany`/`fetchall` behave exactly as before from the caller's perspective — just with the full result set now.

Also added `close_elastic_cursor`, called (best-effort, logged not raised) if pagination exits early via an exception, so a mid-stream failure doesn't leak a still-open server-side cursor.

### Testing

- `es/tests/test_cursor_pagination.py` (new): mocks the transport layer to test the pagination loop directly — no live cluster needed. Confirmed these fail against the pre-fix code (only the first page's rows come back) and pass with the fix. Covers: multi-page accumulation, the single-page case is unaffected, and the cursor gets closed if a follow-up request raises mid-pagination.
- `es/tests/test_dbapi.py::test_execute_fetchall_paginates_past_fetch_size` (new): a live-cluster integration test matching the existing style in this file — connects with a small `fetch_size` against the `flights` fixture (31 rows) and asserts all 31 come back. I don't have Docker available in my environment to run this one myself; it should run in this repo's existing CI matrix (`test-elasticsearch7`/`test-elasticsearch8`) the same way the rest of `test_dbapi.py` does. Scoped to skip on the OpenSearch/opendistro driver since this is specifically the Elasticsearch `_sql` cursor protocol.
- `black`, `flake8`, `mypy` all pass on the changed files.

### Scope note

This PR only touches `es/elastic/api.py` (the plain Elasticsearch driver), not `es/opendistro/api.py`. I didn't investigate whether OpenDistro/OpenSearch's SQL plugin has an analogous pagination gap — that'd be a separate change if it does.